### PR TITLE
Use Structure Void instead of Air for Display Blocks

### DIFF
--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/bushes/HarvestableBush.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/bushes/HarvestableBush.java
@@ -74,7 +74,7 @@ public class HarvestableBush extends CultivationBush implements CultivationHarve
     public void whenPlaced(@NotNull BlockPlaceEvent event) {
         super.whenPlaced(event);
         addDisplayBush(event.getBlock().getLocation());
-        event.getBlock().setType(Material.AIR);
+        event.getBlock().setType(Material.STRUCTURE_VOID);
     }
 
     @Nonnull

--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/HarvestablePlant.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/HarvestablePlant.java
@@ -117,7 +117,7 @@ public class HarvestablePlant extends CultivationPlant implements CultivationHar
             } else {
                 removeItems(block.getLocation());
             }
-            block.setType(Material.AIR);
+            block.setType(Material.STRUCTURE_VOID);
         } else if (growthStage == 2) {
             ItemStack itemStack = getRandomItemWithDropModifier(block.getLocation());
             if (itemStack != null) {

--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/NothingPlant.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/NothingPlant.java
@@ -43,7 +43,7 @@ public class NothingPlant extends CultivationPlant {
             }
         } else if (growthStage == 1) {
             addDisplayPlant(block.getLocation());
-            block.setType(Material.AIR);
+            block.setType(Material.STRUCTURE_VOID);
         }
         BlockStorage.addBlockInfo(block, Keys.FLORA_GROWTH_STAGE, String.valueOf(growthStage));
     }


### PR DESCRIPTION
This PR makes the plants & bushes use a structure void at the location of the plant/bush instead of just air (when applicable). This allows other slimefun addons such as SlimeHUD to display what plant they are looking at. As well as add a hitbox (which can be passed through) to the block.

This PR is not tested yet so I wouldn't merge it but after testing everything I'll make a comment here 👍 