### PR TITLE
Fix pack stacking exploit

### DIFF
--- a/src/main/java/dev/sefiraat/cultivation/implementation/listeners/SeedPackListener.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/listeners/SeedPackListener.java
@@ -38,35 +38,38 @@ public class SeedPackListener implements Listener {
         for (ItemStack content : player.getInventory().getContents()) {
             SlimefunItem packItem = SlimefunItem.getByItem(content);
             if (packItem instanceof SeedPack) {
-                ItemMeta contentMeta = content.getItemMeta();
-                SeedPackInstance instance = PersistentDataAPI.get(
-                    contentMeta,
-                    SeedPackDataType.KEY,
-                    SeedPackDataType.TYPE
-                );
+                int packStack = content.getAmount();
+                if (packStack <= 1) {
+                    ItemMeta contentMeta = content.getItemMeta();
+                    SeedPackInstance instance = PersistentDataAPI.get(
+                        contentMeta,
+                        SeedPackDataType.KEY,
+                        SeedPackDataType.TYPE
+                    );
 
-                if (instance == null || !instance.getStoredItemId().equals(plant.getId())) {
-                    continue;
+                    if (instance == null || !instance.getStoredItemId().equals(plant.getId())) {
+                        continue;
+                    }
+
+                    ItemMeta dropMeta = itemStack.getItemMeta();
+                    FloraLevelProfile profile = PersistentDataAPI.get(
+                        dropMeta,
+                        FloraLevelProfileDataType.KEY,
+                        FloraLevelProfileDataType.TYPE
+                    );
+
+                    if (profile == null) {
+                        continue;
+                    }
+
+                    instance.add(profile, itemStack.getAmount());
+                    PersistentDataAPI.set(contentMeta, SeedPackDataType.KEY, SeedPackDataType.TYPE, instance);
+                    content.setItemMeta(contentMeta);
+                    event.setCancelled(true);
+                    ParticleUtils.displayParticleRandomly(item, 0.5, 5, plant.getTheme().getDustOptions(1));
+                    item.remove();
+                    return;
                 }
-
-                ItemMeta dropMeta = itemStack.getItemMeta();
-                FloraLevelProfile profile = PersistentDataAPI.get(
-                    dropMeta,
-                    FloraLevelProfileDataType.KEY,
-                    FloraLevelProfileDataType.TYPE
-                );
-
-                if (profile == null) {
-                    continue;
-                }
-
-                instance.add(profile, itemStack.getAmount());
-                PersistentDataAPI.set(contentMeta, SeedPackDataType.KEY, SeedPackDataType.TYPE, instance);
-                content.setItemMeta(contentMeta);
-                event.setCancelled(true);
-                ParticleUtils.displayParticleRandomly(item, 0.5, 5, plant.getTheme().getDustOptions(1));
-                item.remove();
-                return;
             }
         }
     }

--- a/src/main/java/dev/sefiraat/cultivation/implementation/listeners/SeedPackListener.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/listeners/SeedPackListener.java
@@ -40,38 +40,40 @@ public class SeedPackListener implements Listener {
             if (packItem instanceof SeedPack) {
                 int packStack = content.getAmount();
                 if (packStack != 1) {
-                    ItemMeta contentMeta = content.getItemMeta();
-                    SeedPackInstance instance = PersistentDataAPI.get(
-                        contentMeta,
-                        SeedPackDataType.KEY,
-                        SeedPackDataType.TYPE
-                    );
-
-                    if (instance == null || !instance.getStoredItemId().equals(plant.getId())) {
-                        continue;
-                    }
-
-                    ItemMeta dropMeta = itemStack.getItemMeta();
-                    FloraLevelProfile profile = PersistentDataAPI.get(
-                        dropMeta,
-                        FloraLevelProfileDataType.KEY,
-                        FloraLevelProfileDataType.TYPE
-                    );
-
-                    if (profile == null) {
-                        continue;
-                    }
-
-                    instance.add(profile, itemStack.getAmount());
-                    PersistentDataAPI.set(contentMeta, SeedPackDataType.KEY, SeedPackDataType.TYPE, instance);
-                    content.setItemMeta(contentMeta);
-                    event.setCancelled(true);
-                    ParticleUtils.displayParticleRandomly(item, 0.5, 5, plant.getTheme().getDustOptions(1));
-                    item.remove();
                     return;
                 }
+                ItemMeta contentMeta = content.getItemMeta();
+                SeedPackInstance instance = PersistentDataAPI.get(
+                    contentMeta,
+                    SeedPackDataType.KEY,
+                    SeedPackDataType.TYPE
+                );
+
+                if (instance == null || !instance.getStoredItemId().equals(plant.getId())) {
+                    continue;
+                }
+
+                ItemMeta dropMeta = itemStack.getItemMeta();
+                FloraLevelProfile profile = PersistentDataAPI.get(
+                    dropMeta,
+                    FloraLevelProfileDataType.KEY,
+                    FloraLevelProfileDataType.TYPE
+                );
+
+                if (profile == null) {
+                    continue;
+                }
+
+                instance.add(profile, itemStack.getAmount());
+                PersistentDataAPI.set(contentMeta, SeedPackDataType.KEY, SeedPackDataType.TYPE, instance);
+                content.setItemMeta(contentMeta);
+                event.setCancelled(true);
+                ParticleUtils.displayParticleRandomly(item, 0.5, 5, plant.getTheme().getDustOptions(1));
+                item.remove();
+                return;
             }
         }
     }
-
 }
+
+

--- a/src/main/java/dev/sefiraat/cultivation/implementation/listeners/SeedPackListener.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/listeners/SeedPackListener.java
@@ -38,8 +38,7 @@ public class SeedPackListener implements Listener {
         for (ItemStack content : player.getInventory().getContents()) {
             SlimefunItem packItem = SlimefunItem.getByItem(content);
             if (packItem instanceof SeedPack) {
-                int packStack = content.getAmount();
-                if (packStack != 1) {
+                if (content.getAmount() != 1) {
                     return;
                 }
                 ItemMeta contentMeta = content.getItemMeta();

--- a/src/main/java/dev/sefiraat/cultivation/implementation/listeners/SeedPackListener.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/listeners/SeedPackListener.java
@@ -39,7 +39,7 @@ public class SeedPackListener implements Listener {
             SlimefunItem packItem = SlimefunItem.getByItem(content);
             if (packItem instanceof SeedPack) {
                 int packStack = content.getAmount();
-                if (packStack <= 1) {
+                if (packStack != 1) {
                     ItemMeta contentMeta = content.getItemMeta();
                     SeedPackInstance instance = PersistentDataAPI.get(
                         contentMeta,


### PR DESCRIPTION
This is a simple fix for Seed Pack stacking. If a player sets 2 packs to the same seed, they can be restacked, then used together to reproduce more drops than they should.