### PR TITLE
Fix plant dupe

### DIFF
--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/CultivationPlant.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/CultivationPlant.java
@@ -160,6 +160,7 @@ public abstract class CultivationPlant extends CultivationFloraItem<CultivationP
         location.getWorld().dropItem(location.clone().add(0.5, 0.5, 0.5), itemToDrop);
         removeLevelProfile(location);
         event.setDropItems(false);
+        location.getBlock().setType(Material.AIR);
     }
 
     public ItemStack getDroppedItemStack(@Nonnull Location location) {


### PR DESCRIPTION
Simple fix for https://github.com/Sefiraat/Cultivation/issues/70 by setting the material to air at the end of the CultivationPlant onBreak method. Tested it works with plants and also with crop sticks, but I am not too familiar with Cultivation (patching this as someone reported it on my server) so more testing by someone who knows more than me is ideal.