### PR TITLE
[Performance] Replace Removing & Adding entities with Updating entities

### DIFF
--- a/src/main/java/dev/sefiraat/cultivation/api/interfaces/CultivationBushHolder.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/interfaces/CultivationBushHolder.java
@@ -50,17 +50,17 @@ public interface CultivationBushHolder {
         }
     }
 
-    default void addItemsToDisplay(@Nonnull Location location, @Nonnull ItemStack itemStack) {
+    default void growItems(@Nonnull Location location, @Nonnull ItemStack itemStack) {
         if (hasDisplayBush(location)) {
             DisplayGroup group = getBushDisplayGroup(location);
-            DisplayGroupGenerators.addItemsToPlant(group, itemStack);
+            DisplayGroupGenerators.growItemsInBush(group, itemStack);
         }
     }
 
-    default void removeItems(@Nonnull Location location) {
+    default void hideItems(@Nonnull Location location) {
         if (hasDisplayBush(location)) {
             DisplayGroup group = getBushDisplayGroup(location);
-            DisplayGroupGenerators.removeItemsFromPlant(group);
+            DisplayGroupGenerators.hideItemsInPlant(group);
         }
     }
 

--- a/src/main/java/dev/sefiraat/cultivation/api/interfaces/CultivationPlantHolder.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/interfaces/CultivationPlantHolder.java
@@ -43,17 +43,17 @@ public interface CultivationPlantHolder {
         BlockStorage.addBlockInfo(location, GROUP_PARENT, displayGroup.getParentUUID().toString());
     }
 
-    default void addItemsToDisplay(@Nonnull Location location, @Nonnull ItemStack itemStack) {
+    default void growItems(@Nonnull Location location, @Nonnull ItemStack itemStack) {
         if (hasDisplayPlant(location)) {
             DisplayGroup group = getPlantDisplayGroup(location);
-            DisplayGroupGenerators.addItemsToPlant(group, itemStack);
+            DisplayGroupGenerators.growItemsInPlant(group, itemStack);
         }
     }
 
-    default void removeItems(@Nonnull Location location) {
+    default void hideItems(@Nonnull Location location) {
         if (hasDisplayPlant(location)) {
             DisplayGroup group = getPlantDisplayGroup(location);
-            DisplayGroupGenerators.removeItemsFromPlant(group);
+            DisplayGroupGenerators.hideItemsInPlant(group);
         }
     }
 

--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/bushes/HarvestableBush.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/bushes/HarvestableBush.java
@@ -100,12 +100,12 @@ public class HarvestableBush extends CultivationBush implements CultivationHarve
         Location location = block.getLocation();
         setAge(location, growthStage);
         if (growthStage == 0) {
-            removeItems(location);
+            hideItems(location);
         } else if (growthStage == 3) {
             ItemStack itemStack = getRandomItem();
             if (itemStack != null) {
                 nextDrop.put(block.getLocation(), itemStack);
-                addItemsToDisplay(block.getLocation(), itemStack.clone());
+                growItems(block.getLocation(), itemStack.clone());
             }
         }
         BlockStorage.addBlockInfo(block, Keys.FLORA_GROWTH_STAGE, String.valueOf(growthStage));

--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/HarvestablePlant.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/HarvestablePlant.java
@@ -114,9 +114,9 @@ public class HarvestablePlant extends CultivationPlant implements CultivationHar
         } else if (growthStage == 1) {
             if (!hasDisplayPlant(block)) {
                 addDisplayPlant(block.getLocation());
-            } else {
-                hideItems(block.getLocation());
+                growItems(block.getLocation(), new ItemStack(Material.AIR));
             }
+            hideItems(block.getLocation());
             block.setType(Material.AIR);
         } else if (growthStage == 2) {
             ItemStack itemStack = getRandomItemWithDropModifier(block.getLocation());

--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/HarvestablePlant.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/HarvestablePlant.java
@@ -115,14 +115,14 @@ public class HarvestablePlant extends CultivationPlant implements CultivationHar
             if (!hasDisplayPlant(block)) {
                 addDisplayPlant(block.getLocation());
             } else {
-                removeItems(block.getLocation());
+                hideItems(block.getLocation());
             }
             block.setType(Material.AIR);
         } else if (growthStage == 2) {
             ItemStack itemStack = getRandomItemWithDropModifier(block.getLocation());
             if (itemStack != null) {
                 nextDrop.put(block.getLocation(), itemStack);
-                addItemsToDisplay(block.getLocation(), itemStack.clone());
+                growItems(block.getLocation(), itemStack.clone());
             }
         }
         BlockStorage.addBlockInfo(block, Keys.FLORA_GROWTH_STAGE, String.valueOf(growthStage));

--- a/src/main/java/dev/sefiraat/cultivation/implementation/slimefun/machines/GardenCloche.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/slimefun/machines/GardenCloche.java
@@ -118,7 +118,7 @@ public class GardenCloche extends SlimefunItem implements DisplayInteractable, E
                     } else {
                         Bukkit.getScheduler().runTask(
                             Cultivation.getInstance(),
-                            () -> removePlantFromDisplay(location)
+                            () -> hidePlantInDisplay(location)
                         );
                     }
                 }
@@ -182,10 +182,10 @@ public class GardenCloche extends SlimefunItem implements DisplayInteractable, E
         }
     }
 
-    private void removePlantFromDisplay(@Nonnull Location location) {
+    private void hidePlantInDisplay(@Nonnull Location location) {
         DisplayGroup displayGroup = getDisplayGroup(location);
         if (displayGroup != null) {
-            DisplayGroupGenerators.removePlantFromCloche(displayGroup);
+            DisplayGroupGenerators.hidePlantInCloche(displayGroup);
             BlockStorage.addBlockInfo(location, KEY_PLANT, null);
         }
     }

--- a/src/main/java/dev/sefiraat/cultivation/implementation/utils/DisplayGroupGenerators.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/utils/DisplayGroupGenerators.java
@@ -263,7 +263,7 @@ public final class DisplayGroupGenerators {
         if (drop1 instanceof ItemDisplay itemDisplay) {
             itemDisplay.setItemStack(itemStack);
             itemDisplay.setInterpolationDelay(-1);
-            itemDisplay.setInterpolationDuration(10);
+            itemDisplay.setInterpolationDuration(20);
             itemDisplay.setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation());
         }
     }
@@ -273,7 +273,7 @@ public final class DisplayGroupGenerators {
         if (drop1 instanceof ItemDisplay itemDisplay) {
             itemDisplay.setItemStack(itemStack);
             itemDisplay.setInterpolationDelay(-1);
-            itemDisplay.setInterpolationDuration(10);
+            itemDisplay.setInterpolationDuration(20);
             itemDisplay.setTransformation(Transformations.BUSH_HANGING_DROP.getTransformation());
         }
     }
@@ -283,19 +283,19 @@ public final class DisplayGroupGenerators {
         final Display drop1 = displays.get("drop_1");
         if (drop1 != null) {
             drop1.setInterpolationDelay(-1);
-            drop1.setInterpolationDuration(10);
+            drop1.setInterpolationDuration(2);
             drop1.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
         }
         final Display drop2 = displays.get("drop_2");
         if (drop2 != null) {
             drop2.setInterpolationDelay(-1);
-            drop2.setInterpolationDuration(10);
+            drop2.setInterpolationDuration(2);
             drop2.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
         }
         final Display drop3 = displays.get("drop_3");
         if (drop3 != null) {
             drop3.setInterpolationDelay(-1);
-            drop3.setInterpolationDuration(10);
+            drop3.setInterpolationDuration(2);
             drop3.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
         }
     }

--- a/src/main/java/dev/sefiraat/cultivation/implementation/utils/DisplayGroupGenerators.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/utils/DisplayGroupGenerators.java
@@ -125,22 +125,39 @@ public final class DisplayGroupGenerators {
                 .setTransformation(Transformations.CLOCHE_DIRT.getTransformation())
                 .build(displayGroup)
         );
+        displayGroup.addDisplay(
+            "plant",
+            new ItemDisplayBuilder()
+                .setItemStack(new ItemStack(Material.AIR))
+                .setGroupParentOffset(new Vector(0, 1.25, 0))
+                .setTransformation(Transformations.HIDDEN.getTransformation())
+                .build(displayGroup)
+        );
         return displayGroup;
     }
 
     public static void addPlantToCloche(@Nonnull DisplayGroup displayGroup) {
-        displayGroup.addDisplay(
-            "plant",
-            new ItemDisplayBuilder()
-                .setGroupParentOffset(new Vector(0, 1.25, 0))
-                .setTransformation(Transformations.CLOCHE_GLASS.getTransformation())
-                .setItemStack(new ItemStack(Material.SMALL_DRIPLEAF))
-                .build(displayGroup)
-        );
+        final Map<String, Display> displays = displayGroup.getDisplays();
+        if (!displays.containsKey("plant")) {
+            displayGroup.addDisplay(
+                    "plant",
+                    new ItemDisplayBuilder()
+                        .setItemStack(new ItemStack(Material.AIR))
+                        .setGroupParentOffset(new Vector(0, 1.25, 0))
+                        .setTransformation(Transformations.HIDDEN.getTransformation())
+                        .build(displayGroup)
+            );
+        }
+        updateItemDisplay(displayGroup, "plant", Transformations.PLANT_HANGING_DROP, new ItemStack(Material.SMALL_DRIPLEAF));
     }
 
-    public static void removePlantFromCloche(@Nonnull DisplayGroup displayGroup) {
-        displayGroup.killDisplay("plant");
+    public static void hidePlantInCloche(@Nonnull DisplayGroup displayGroup) {
+        if (displayGroup.getDisplays().get("plant") instanceof ItemDisplay itemDisplay) {
+            itemDisplay.setItemStack(new ItemStack(Material.AIR));
+            itemDisplay.setInterpolationDelay(-1);
+            itemDisplay.setInterpolationDuration(4);
+            itemDisplay.setTransformation(Transformations.HIDDEN.getTransformation());
+        }
     }
 
     public static DisplayGroup generatePlant(@Nonnull Location location) {
@@ -188,33 +205,33 @@ public final class DisplayGroupGenerators {
                     new ItemDisplayBuilder()
                             .setGroupParentOffset(new Vector(0.32, 0.08, 0.32))
                             .setItemStack(itemStack)
-                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .setTransformation(Transformations.HIDDEN.getTransformation())
                             .build(displayGroup)
             );
         }
-        updateItemInPlant(displayGroup, itemStack, "drop_1");
+        updateItemDisplay(displayGroup, "drop_1", Transformations.PLANT_HANGING_DROP, itemStack);
         if (!displays.containsKey("drop_2")) {
             displayGroup.addDisplay(
                     "drop_2",
                     new ItemDisplayBuilder()
                             .setGroupParentOffset(new Vector(-0.32, 0.39, -0.32))
                             .setItemStack(itemStack)
-                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .setTransformation(Transformations.HIDDEN.getTransformation())
                             .build(displayGroup)
             );
         }
-        updateItemInPlant(displayGroup, itemStack, "drop_2");
+        updateItemDisplay(displayGroup, "drop_2", Transformations.PLANT_HANGING_DROP, itemStack);
         if (!displays.containsKey("drop_3")) {
             displayGroup.addDisplay(
                     "drop_3",
                     new ItemDisplayBuilder()
                             .setGroupParentOffset(new Vector(-0.32, 0.64, 0.32))
                             .setItemStack(itemStack)
-                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .setTransformation(Transformations.HIDDEN.getTransformation())
                             .build(displayGroup)
             );
         }
-        updateItemInPlant(displayGroup, itemStack, "drop_3");
+        updateItemDisplay(displayGroup, "drop_3", Transformations.PLANT_HANGING_DROP, itemStack);
     }
 
     public static void growItemsInBush(@Nonnull DisplayGroup displayGroup, @Nonnull Material material) {
@@ -229,52 +246,42 @@ public final class DisplayGroupGenerators {
                     new ItemDisplayBuilder()
                             .setGroupParentOffset(new Vector(0.32, 0.19, 0.32))
                             .setItemStack(itemStack)
-                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .setTransformation(Transformations.HIDDEN.getTransformation())
                             .build(displayGroup)
             );
         }
-        updateItemInBush(displayGroup, itemStack, "drop_1");
+        updateItemDisplay(displayGroup, "drop_1", Transformations.BUSH_HANGING_DROP, itemStack);
         if (!displays.containsKey("drop_2")) {
             displayGroup.addDisplay(
                     "drop_2",
                     new ItemDisplayBuilder()
                             .setGroupParentOffset(new Vector(-0.32, 0.43, -0.32))
                             .setItemStack(itemStack)
-                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .setTransformation(Transformations.HIDDEN.getTransformation())
                             .build(displayGroup)
             );
         }
-        updateItemInBush(displayGroup, itemStack, "drop_2");
+        updateItemDisplay(displayGroup, "drop_2", Transformations.BUSH_HANGING_DROP, itemStack);
         if (!displays.containsKey("drop_3")) {
             displayGroup.addDisplay(
                     "drop_3",
                     new ItemDisplayBuilder()
                             .setGroupParentOffset(new Vector(-0.32, 0.71, 0.32))
                             .setItemStack(itemStack)
-                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .setTransformation(Transformations.HIDDEN.getTransformation())
                             .build(displayGroup)
             );
         }
-        updateItemInBush(displayGroup, itemStack, "drop_3");
+        updateItemDisplay(displayGroup, "drop_3", Transformations.BUSH_HANGING_DROP, itemStack);
     }
 
-    public static void updateItemInPlant(@Nonnull DisplayGroup displayGroup, @Nonnull ItemStack itemStack, @Nonnull String drop) {
-        final Display drop1 = displayGroup.getDisplays().get(drop);
-        if (drop1 instanceof ItemDisplay itemDisplay) {
+    public static void updateItemDisplay(@Nonnull DisplayGroup displayGroup, @Nonnull String displayName, Transformations transformation, @Nonnull ItemStack itemStack) {
+        final Display display = displayGroup.getDisplays().get(displayName);
+        if (display instanceof ItemDisplay itemDisplay) {
             itemDisplay.setItemStack(itemStack);
             itemDisplay.setInterpolationDelay(-1);
             itemDisplay.setInterpolationDuration(20);
-            itemDisplay.setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation());
-        }
-    }
-
-    public static void updateItemInBush(@Nonnull DisplayGroup displayGroup, @Nonnull ItemStack itemStack, @Nonnull String drop) {
-        final Display drop1 = displayGroup.getDisplays().get(drop);
-        if (drop1 instanceof ItemDisplay itemDisplay) {
-            itemDisplay.setItemStack(itemStack);
-            itemDisplay.setInterpolationDelay(-1);
-            itemDisplay.setInterpolationDuration(20);
-            itemDisplay.setTransformation(Transformations.BUSH_HANGING_DROP.getTransformation());
+            itemDisplay.setTransformation(transformation.getTransformation());
         }
     }
 
@@ -284,19 +291,19 @@ public final class DisplayGroupGenerators {
         if (drop1 != null) {
             drop1.setInterpolationDelay(-1);
             drop1.setInterpolationDuration(2);
-            drop1.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
+            drop1.setTransformation(Transformations.HIDDEN.getTransformation());
         }
         final Display drop2 = displays.get("drop_2");
         if (drop2 != null) {
             drop2.setInterpolationDelay(-1);
             drop2.setInterpolationDuration(2);
-            drop2.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
+            drop2.setTransformation(Transformations.HIDDEN.getTransformation());
         }
         final Display drop3 = displays.get("drop_3");
         if (drop3 != null) {
             drop3.setInterpolationDelay(-1);
             drop3.setInterpolationDuration(2);
-            drop3.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
+            drop3.setTransformation(Transformations.HIDDEN.getTransformation());
         }
     }
 

--- a/src/main/java/dev/sefiraat/cultivation/implementation/utils/DisplayGroupGenerators.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/utils/DisplayGroupGenerators.java
@@ -11,11 +11,13 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.entity.BlockDisplay;
 import org.bukkit.entity.Display;
+import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 
 public final class DisplayGroupGenerators {
 
@@ -174,72 +176,128 @@ public final class DisplayGroupGenerators {
         }
     }
 
-    public static void addItemsToPlant(@Nonnull DisplayGroup displayGroup, @Nonnull Material material) {
-        addItemsToPlant(displayGroup, new ItemStack(material));
+    public static void growItemsInPlant(@Nonnull DisplayGroup displayGroup, @Nonnull Material material) {
+        growItemsInPlant(displayGroup, new ItemStack(material));
     }
 
-    public static void addItemsToPlant(@Nonnull DisplayGroup displayGroup, @Nonnull ItemStack itemStack) {
-        displayGroup.addDisplay(
-            "drop_1",
-            new ItemDisplayBuilder()
-                .setGroupParentOffset(new Vector(0.32, 0.08, 0.32))
-                .setItemStack(itemStack)
-                .setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation())
-                .build(displayGroup)
-        );
-        displayGroup.addDisplay(
-            "drop_2",
-            new ItemDisplayBuilder()
-                .setGroupParentOffset(new Vector(-0.32, 0.39, -0.32))
-                .setItemStack(itemStack)
-                .setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation())
-                .build(displayGroup)
-        );
-        displayGroup.addDisplay(
-            "drop_3",
-            new ItemDisplayBuilder()
-                .setGroupParentOffset(new Vector(-0.32, 0.64, 0.32))
-                .setItemStack(itemStack)
-                .setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation())
-                .build(displayGroup)
-        );
+    public static void growItemsInPlant(@Nonnull DisplayGroup displayGroup, @Nonnull ItemStack itemStack) {
+        final Map<String, Display> displays = displayGroup.getDisplays();
+        if (!displays.containsKey("drop_1")) {
+            displayGroup.addDisplay(
+                    "drop_1",
+                    new ItemDisplayBuilder()
+                            .setGroupParentOffset(new Vector(0.32, 0.08, 0.32))
+                            .setItemStack(itemStack)
+                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .build(displayGroup)
+            );
+        }
+        updateItemInPlant(displayGroup, itemStack, "drop_1");
+        if (!displays.containsKey("drop_2")) {
+            displayGroup.addDisplay(
+                    "drop_2",
+                    new ItemDisplayBuilder()
+                            .setGroupParentOffset(new Vector(-0.32, 0.39, -0.32))
+                            .setItemStack(itemStack)
+                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .build(displayGroup)
+            );
+        }
+        updateItemInPlant(displayGroup, itemStack, "drop_2");
+        if (!displays.containsKey("drop_3")) {
+            displayGroup.addDisplay(
+                    "drop_3",
+                    new ItemDisplayBuilder()
+                            .setGroupParentOffset(new Vector(-0.32, 0.64, 0.32))
+                            .setItemStack(itemStack)
+                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .build(displayGroup)
+            );
+        }
+        updateItemInPlant(displayGroup, itemStack, "drop_3");
     }
 
-    public static void addItemsToBush(@Nonnull DisplayGroup displayGroup, @Nonnull Material material) {
-        addItemsToBush(displayGroup, new ItemStack(material));
+    public static void growItemsInBush(@Nonnull DisplayGroup displayGroup, @Nonnull Material material) {
+        growItemsInBush(displayGroup, new ItemStack(material));
     }
 
-    public static void addItemsToBush(@Nonnull DisplayGroup displayGroup, @Nonnull ItemStack itemStack) {
-        displayGroup.addDisplay(
-            "drop_1",
-            new ItemDisplayBuilder()
-                .setGroupParentOffset(new Vector(0.32, 0.19, 0.32))
-                .setItemStack(itemStack)
-                .setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation())
-                .build(displayGroup)
-        );
-        displayGroup.addDisplay(
-            "drop_2",
-            new ItemDisplayBuilder()
-                .setGroupParentOffset(new Vector(-0.32, 0.43, -0.32))
-                .setItemStack(itemStack)
-                .setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation())
-                .build(displayGroup)
-        );
-        displayGroup.addDisplay(
-            "drop_3",
-            new ItemDisplayBuilder()
-                .setGroupParentOffset(new Vector(-0.32, 0.71, 0.32))
-                .setItemStack(itemStack)
-                .setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation())
-                .build(displayGroup)
-        );
+    public static void growItemsInBush(@Nonnull DisplayGroup displayGroup, @Nonnull ItemStack itemStack) {
+        final Map<String, Display> displays = displayGroup.getDisplays();
+        if (!displays.containsKey("drop_1")) {
+            displayGroup.addDisplay(
+                    "drop_1",
+                    new ItemDisplayBuilder()
+                            .setGroupParentOffset(new Vector(0.32, 0.19, 0.32))
+                            .setItemStack(itemStack)
+                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .build(displayGroup)
+            );
+        }
+        updateItemInBush(displayGroup, itemStack, "drop_1");
+        if (!displays.containsKey("drop_2")) {
+            displayGroup.addDisplay(
+                    "drop_2",
+                    new ItemDisplayBuilder()
+                            .setGroupParentOffset(new Vector(-0.32, 0.43, -0.32))
+                            .setItemStack(itemStack)
+                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .build(displayGroup)
+            );
+        }
+        updateItemInBush(displayGroup, itemStack, "drop_2");
+        if (!displays.containsKey("drop_3")) {
+            displayGroup.addDisplay(
+                    "drop_3",
+                    new ItemDisplayBuilder()
+                            .setGroupParentOffset(new Vector(-0.32, 0.71, 0.32))
+                            .setItemStack(itemStack)
+                            .setTransformation(Transformations.HIDDEN_DROP.getTransformation())
+                            .build(displayGroup)
+            );
+        }
+        updateItemInBush(displayGroup, itemStack, "drop_3");
     }
 
-    public static void removeItemsFromPlant(@Nonnull DisplayGroup displayGroup) {
-        displayGroup.killDisplay("drop_1");
-        displayGroup.killDisplay("drop_2");
-        displayGroup.killDisplay("drop_3");
+    public static void updateItemInPlant(@Nonnull DisplayGroup displayGroup, @Nonnull ItemStack itemStack, @Nonnull String drop) {
+        final Display drop1 = displayGroup.getDisplays().get(drop);
+        if (drop1 instanceof ItemDisplay itemDisplay) {
+            itemDisplay.setItemStack(itemStack);
+            itemDisplay.setInterpolationDelay(-1);
+            itemDisplay.setInterpolationDuration(10);
+            itemDisplay.setTransformation(Transformations.PLANT_HANGING_DROP.getTransformation());
+        }
+    }
+
+    public static void updateItemInBush(@Nonnull DisplayGroup displayGroup, @Nonnull ItemStack itemStack, @Nonnull String drop) {
+        final Display drop1 = displayGroup.getDisplays().get(drop);
+        if (drop1 instanceof ItemDisplay itemDisplay) {
+            itemDisplay.setItemStack(itemStack);
+            itemDisplay.setInterpolationDelay(-1);
+            itemDisplay.setInterpolationDuration(10);
+            itemDisplay.setTransformation(Transformations.BUSH_HANGING_DROP.getTransformation());
+        }
+    }
+
+    public static void hideItemsInPlant(@Nonnull DisplayGroup displayGroup) {
+        final Map<String, Display> displays = displayGroup.getDisplays();
+        final Display drop1 = displays.get("drop_1");
+        if (drop1 != null) {
+            drop1.setInterpolationDelay(-1);
+            drop1.setInterpolationDuration(10);
+            drop1.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
+        }
+        final Display drop2 = displays.get("drop_2");
+        if (drop2 != null) {
+            drop2.setInterpolationDelay(-1);
+            drop2.setInterpolationDuration(10);
+            drop2.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
+        }
+        final Display drop3 = displays.get("drop_3");
+        if (drop3 != null) {
+            drop3.setInterpolationDelay(-1);
+            drop3.setInterpolationDuration(10);
+            drop3.setTransformation(Transformations.HIDDEN_DROP.getTransformation());
+        }
     }
 
     public static DisplayGroup generateBaseCounter(@Nonnull Location location) {

--- a/src/main/java/dev/sefiraat/cultivation/implementation/utils/Transformations.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/utils/Transformations.java
@@ -22,7 +22,7 @@ public enum Transformations {
                            .secondRotation(RotationFace.SIDE, 90)
                            .build()
     ),
-    HIDDEN_DROP(new TransformationBuilder()
+    HIDDEN(new TransformationBuilder()
             .scale(0f, 0f, 0f)
             .build()
     ),

--- a/src/main/java/dev/sefiraat/cultivation/implementation/utils/Transformations.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/utils/Transformations.java
@@ -22,6 +22,10 @@ public enum Transformations {
                            .secondRotation(RotationFace.SIDE, 90)
                            .build()
     ),
+    HIDDEN_DROP(new TransformationBuilder()
+            .scale(0f, 0f, 0f)
+            .build()
+    ),
     PLANT_HANGING_DROP(new TransformationBuilder()
                            .scale(0.2f, 0.2f, 0.2f)
                            .build()


### PR DESCRIPTION
Currently cultivation whenever harvesting from a plant, will remove the entities representing the item, and when they grow it adds the entities. This is quite laggy when done many many times a second, which can be easily achieved with a macro on an afk player. To combat this, this PR replaces that system with its own. It hides the entities by setting the scale to be 0, 0, 0 when harvested, and then to its normal size when grown. Unintentionally this also fixes a couple bugs with the bushes, as they did not use the proper transformations or methods that were created for them. I have also included interpolation, so the drops actually "grow" and "harvest", its a nice visual touch that has no impact on the server as interpolation is purely client sided. 

Below are some profiles with and without the changes:
- I also placed a lot of entity heavy quaptic blocks as well to try and simulate having more entities on the server

With: https://spark.lucko.me/lXZ2NaOQZx
Without: https://spark.lucko.me/RJYgpWhhBL

This was also only done on a local test server, so the differences would be more dramatic on a production server. I say this cause on Meta tps would be at 20, and then 2 people would be macro farming cultivation (10 10 10 plants) and tps would drop to 8-12.