### PR TITLE
[Feature] Use Structure Void instead of Air

### DIFF
--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/bushes/HarvestableBush.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/bushes/HarvestableBush.java
@@ -74,7 +74,7 @@ public class HarvestableBush extends CultivationBush implements CultivationHarve
     public void whenPlaced(@NotNull BlockPlaceEvent event) {
         super.whenPlaced(event);
         addDisplayBush(event.getBlock().getLocation());
-        event.getBlock().setType(Material.AIR);
+        event.getBlock().setType(Material.STRUCTURE_VOID);
     }
 
     @Nonnull

--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/HarvestablePlant.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/HarvestablePlant.java
@@ -117,7 +117,7 @@ public class HarvestablePlant extends CultivationPlant implements CultivationHar
             } else {
                 removeItems(block.getLocation());
             }
-            block.setType(Material.AIR);
+            block.setType(Material.STRUCTURE_VOID);
         } else if (growthStage == 2) {
             ItemStack itemStack = getRandomItemWithDropModifier(block.getLocation());
             if (itemStack != null) {

--- a/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/NothingPlant.java
+++ b/src/main/java/dev/sefiraat/cultivation/api/slimefun/items/plants/NothingPlant.java
@@ -43,7 +43,7 @@ public class NothingPlant extends CultivationPlant {
             }
         } else if (growthStage == 1) {
             addDisplayPlant(block.getLocation());
-            block.setType(Material.AIR);
+            block.setType(Material.STRUCTURE_VOID);
         }
         BlockStorage.addBlockInfo(block, Keys.FLORA_GROWTH_STAGE, String.valueOf(growthStage));
     }

--- a/src/main/java/dev/sefiraat/cultivation/implementation/listeners/CustomPlacementListener.java
+++ b/src/main/java/dev/sefiraat/cultivation/implementation/listeners/CustomPlacementListener.java
@@ -112,6 +112,7 @@ public class CustomPlacementListener implements Listener {
             location.getWorld().dropItem(location, bush.getItem().clone());
             bush.removeBushDisplayGroup(location);
             BlockStorage.clearBlockInfo(location);
+            location.getBlock().setType(Material.AIR);
         }
     }
 


### PR DESCRIPTION
This PR simply sets the block to be a structure void instead of air when the plants or bushes grow. The reason for this is to allow other plugins such as SlimeHUD to properly recognize the plant. It also helps prevent interactions that may other wise break the plant such as piston pushes. (The point of leaving the listeners for that in is that any old plants won't be structure void) 

I've also added a line to set the block to air in the case of killing a bush, as now if its not air it will be a structure void instead. Unless there is a specific reason it doesn't do this already I think this is meant to be here.